### PR TITLE
Use @rpath as install_name prefix on MacOS (fixes #8)

### DIFF
--- a/src/setuptools_dso/dsocmd.py
+++ b/src/setuptools_dso/dsocmd.py
@@ -140,7 +140,9 @@ class dso2libmixin:
                         else:
                             raise RuntimeError("Something wierd happened.  Please report. %s"%full)
 
-                        self._osx_changes.append(('@loader_path/'+fullname, '@loader_path/%s/%s'%(os.path.relpath(dsopath, mypath), fullname)))
+                        p = os.path.relpath(dsopath, mypath)
+                        if p != '.':
+                            soargs.add('-Wl,-rpath,@loader_path/%s' % p)
 
                         # In theory '-dylib_file A:B' asks the linker to do the equivlaent of:
                         #     install_name_tool -change A B
@@ -341,7 +343,7 @@ class build_dso(dso2libmixin, Command):
         if sys.platform == 'darwin':
             # we always want to produce relocatable (movable) binaries
             # this install_name will be replaced below (cf. 'install_name_tool')
-            extra_args.extend(['-install_name', '@loader_path/%s'%solibbase])
+            extra_args.extend(['-install_name', '@rpath/%s'%solibbase, '-Wl,-rpath,@loader_path'])
 
         elif sys.platform == "win32":
             # The .lib is considered "temporary" for extensions, but not for us


### PR DESCRIPTION
@loader_path prefix requires dependent libraries to be in the same
directory or to use install_name_tool to change the name after linking.
With this fix, linker's -rpath can be used instead.