### PR TITLE
Mangle PIP tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,82 @@ jobs:
           (cd src && python -m dsodemo.cli)
           cd ..
 
+  manylinux:
+    runs-on: ubuntu-latest
+    name: Test ${{ matrix.pyver }} / ${{ matrix.manylinux }}_${{ matrix.piparch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        manylinux: ["manylinux1", "manylinux2010", "manylinux2014"]
+        piparch: ["i686", "x86_64"]
+        pyver: ["cp27-cp27m", "cp27-cp27mu", "cp36-cp36m", "cp37-cp37m", "cp38-cp38", "cp39-cp39"]
+        exclude:
+          - manylinux: "manylinux2010"
+            piparch: "i686"
+            pyver: "cp27-cp27m"
+
+          - manylinux: "manylinux2010"
+            piparch: "i686"
+            pyver: "cp27-cp27mu"
+
+          - manylinux: "manylinux2010"
+            piparch: "x86_64"
+            pyver: "cp27-cp27m"
+
+          - manylinux: "manylinux2010"
+            piparch: "x86_64"
+            pyver: "cp27-cp27mu"
+
+          - manylinux: "manylinux2014"
+            piparch: "i686"
+            pyver: "cp27-cp27m"
+
+          - manylinux: "manylinux2014"
+            piparch: "i686"
+            pyver: "cp27-cp27mu"
+
+          - manylinux: "manylinux2014"
+            piparch: "x86_64"
+            pyver: "cp27-cp27m"
+
+          - manylinux: "manylinux2014"
+            piparch: "x86_64"
+            pyver: "cp27-cp27mu"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: |
+          # can't use GHA native docker support since GHA magic binaries need .so absent from old manylinux images :(
+          cat <<EOF > runit.sh
+          #!/bin/sh
+          set -e -x
+          cd /io
+          export PATH="/opt/python/${{ matrix.pyver }}/bin:\$PATH"
+          export SETUPTOOLS_DSO_MANYLINUX="${{ matrix.manylinux }}"
+          which python
+
+          pip download -d dist setuptools wheel
+          python setup.py sdist --formats=gztar
+          pip install -v --no-index -f dist dist/setuptools_dso-*.tar.*
+
+          cd example
+          python setup.py sdist --formats=gztar
+          pip wheel -w ../dist -f ../dist --no-index dist/dsodemo-*.tar.*
+
+          pip install -f ../dist --no-index ../dist/dsodemo*${{ matrix.manylinux }}_${{ matrix.piparch }}*.whl
+
+          cd dist
+          python -m dsodemo.cli
+
+          EOF
+          cat runit.sh
+          chmod +x runit.sh
+          docker pull quay.io/pypa/${{ matrix.manylinux }}_${{ matrix.piparch }}
+          docker run --rm -v `pwd`:/io quay.io/pypa/${{ matrix.manylinux }}_${{ matrix.piparch }} ${{ matrix.pre }} /io/runit.sh
+
   upload:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, manylinux]
     name: Upload
     steps:
       - uses: actions/checkout@v2

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -43,6 +43,19 @@ for a successful source build.
 
 .. literalinclude:: ../example/MANIFEST.in
 
+Using with manylinux
+^^^^^^^^^^^^^^^^^^^^
+
+Using of **auditwheel** with wheel builds from setuptools_dso can cause problems
+as auditwheel has no concept of non-python libraries in python packages.
+
+If **$SETUPTOOLS_DSO_MANYLINUX** contains a manylinux name, setuptools_dso will
+inject this name when building wheels.
+Currently PIP version <=21 will pass this environment variable through to PEP 517 builds.
+eg. ::
+
+    SETUPTOOLS_DSO_MANYLINUX=manylinux1 pip wheel -w dist .
+
 Building a DSO
 --------------
 

--- a/src/setuptools_dso/__init__.py
+++ b/src/setuptools_dso/__init__.py
@@ -39,6 +39,12 @@ def setup(**kws):
     cmdclass_setdefault('bdist_egg', bdist_egg)
     cmdclass_setdefault('build_dso', build_dso)
     cmdclass_setdefault('build_ext', build_ext)
+    try:
+        from .dsocmd import bdist_wheel
+    except ImportError:
+        pass # wheel not installed
+    else:
+        cmdclass_setdefault('bdist_wheel', bdist_wheel)
     kws.setdefault('zip_safe', len(kws.get('ext_modules', []))==0 and len(kws.get('x_dsos', []))==0)
     _setup(**kws)
 


### PR DESCRIPTION
To help dealing with `auditwheel`, add a way to override the platform tag through the environment with `$SETUPTOOLS_DSO_MANYLINUX`.