### PR TITLE
Add setuptools als runtime requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'License :: OSI Approved :: BSD License',
     ],
     python_requires='>=2.7',
+    install_requires = ['setuptools'],
 
     packages=['setuptools_dso'],
     package_dir={'':'src'},


### PR DESCRIPTION
`setuptools_dso` does not declare a dependency on `setuptools`, although it is required during runtime. 

Usually this probably does not show up, since `setuptools` is usually just installed. But it can happen if `setuptools_dso` is deployed in a clean docker container