### PR TITLE
Do not escape $ORIGIN at least on Android

### DIFF
--- a/src/setuptools_dso/dsocmd.py
+++ b/src/setuptools_dso/dsocmd.py
@@ -283,7 +283,8 @@ class dso2libmixin:
                 # For lack of a better idea, give both versions and hope that the non-functional
                 # one is really non-functional.
                 soargs.add('-Wl,-rpath,$ORIGIN/%s'%os.path.relpath(dsopath, mypath))
-                soargs.add(r'-Wl,-rpath,\$ORIGIN/%s'%os.path.relpath(dsopath, mypath))
+                if 'gcc' in self.compiler.linker_so[0]:
+                    soargs.add(r'-Wl,-rpath,\$ORIGIN/%s'%os.path.relpath(dsopath, mypath))
 
         # Do not append to extisting list as it may be shared
         # between multiple extensions


### PR DESCRIPTION
Commit a83de88b ($ORIGIN escaping, 2018) added \$ORIGIN/... to built DSO/Extension with the reason that

    # Some versions of GCC will expand shell macros _internally_ when
    # passing arguments to 'ld', and need '\$ORIGIN'.  And some versions don't,
    # and fail with '\$ORIGIN'.
    # Presumably this was a bug in gcc-wrapper which was fixed at some point.
    #
    # So what to do?
    # For lack of a better idea, give both versions and hope that the non-functional
    # one is really non-functional.

That does not create issues on regular Linux, but on Android it leads to the following warnings issued by system dynamic linker:

    ((1.venv) ) poco:~/setuptools_dso/example/src$ python -m dsodemo.cli
    WARNING: linker: Warning: unable to normalize "\/data/data/com.termux/files/home/setuptools_dso/example/src/dsodemo/ext/../lib" (ignoring)
    WARNING: linker: Warning: unable to normalize "\/data/data/com.termux/files/home/setuptools_dso/example/src/dsodemo/ext/../lib" (ignoring)
    From foo.c
    From bar.cpp

I would say the proper fix would be to drop that $ORIGIN escaping completely, but trying to preserve backward compatibility we can leave it on applied only selectively if the linker is indeed GCC. This fixes the issue on Android/Termux because there the compiler is CLang.

After this patch the warnings are gone:

    ((1.venv) ) poco:~/setuptools_dso/example/src$ python -m dsodemo.cli
    From foo.c
    From bar.cpp

/cc @mdavidsaver